### PR TITLE
fix holyc print formatting table not rendering correctly

### DIFF
--- a/docs/holyc/print.mdx
+++ b/docs/holyc/print.mdx
@@ -21,6 +21,7 @@ There are various formatting codes for different types of data,to use a floating
 
 ```
 The basic formatting codes are:
+
 |Code| Meaning |Type |
 |--|--|---|
 |d|Integer|`I64`|


### PR DESCRIPTION
This fixes the table that does not render properly from https://templeos.me/holyc/printing#basic-formatting

Before: 
<img width="867" alt="image" src="https://user-images.githubusercontent.com/45239828/197120305-bb098292-ecfa-4baf-ae49-d62727f66410.png">

After:
<img width="690" alt="image" src="https://user-images.githubusercontent.com/45239828/197120372-5c8bc206-c3fb-4da5-bd86-3e573531f166.png">
