### PR TITLE
feat: add author display and update existing docs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,16 +1,20 @@
 # Contributing
+
 > **Note** <br>
 > A basic understanding of [React](https://reactjs.org/) and [Markdown](https://https://www.markdownguide.org/) may be nesseciary for editing _some_ features of the site.
 
 ## Editing
-Editing documents on the site require almost no HTML, instead everything is done simply in Markdown. 
 
-Upon pushing to the main branch, the site will be automatically built to the `gh-pages` branch; this requires nothing to be done manually. After being built into HTML files, the page is then served from that branch using GitHub Pages. 
+Editing documents on the site require almost no HTML, instead everything is done simply in Markdown.
+
+Upon pushing to the main branch, the site will be automatically built to the `gh-pages` branch; this requires nothing to be done manually. After being built into HTML files, the page is then served from that branch using GitHub Pages.
 
 That said, understanding the file structure is important to contributing to the site; it may be worth checking out the Docusaurus documentation, if you wish to make any major contributions.
 
 ## File Structure
+
 Editing files couldn't be more simple. To create a page, head into the `docs` directory, then into either `guide` or `holyc` in respect to what you are writing. For example, if I wish to write a page about 'The TempleOS Command Line', then I would create a file: `/docs/guide/category/commandline.mdx` (MDX is React's own version of MD, only use MDX if you wish to use react specific features).
+
 ```
 docs
 ├── guide
@@ -18,19 +22,25 @@ docs
 │   │   ├── commandline.mdx
 │   │   └── the-basics.md
 ```
+
 Next, you must insert the following lines into the start of your markdown page:
+
 ```
 ---
 id: cli
 title: Command Line
+author: github username
 ---
 ```
-* `id` is used to reference the page outside (used soon).
-* `title` is what is seen in the sidebar, if no Heading is used in the document, the heading will result to this.
+
+- `id` is used to reference the page outside (used soon).
+- `title` is what is seen in the sidebar, if no Heading is used in the document, the heading will result to this.
+- `author` is your github username so the doc page displays your info at the bottom
 
 Finally, you'll need to tell the site where to put this file. Pages are never indexed automatically, this is better to ensure that everything is in the right order, pages appear on the sidebar only if they are referenced in `sidebars.js`, pages will not be able to be found via a URL either unless referenced.
 
 This is a snippet of the current `sidebars.js` file:
+
 ```js
 const sidebars = {
   guide: [
@@ -54,14 +64,19 @@ const sidebars = {
       ],
     },
 ```
+
 This should be pretty self explanatory if you give it a moment, it's essentially a `dict` containing the index. Reference a page using it's ID, not it's location. For example, our page that we made prior, should be referenced not as:
+
 ```
 /docs/guide/category/commandline.md
 ```
+
 but instead using its ID:
+
 ```
 /docs/guide/category/cli
 ```
 
 ## Static
+
 If your page requires the usage of images, add them to the `/static` directory in the category it belongs to. Please make a folder for your page itself and add all the images there. Everything in this directory will be built to `/`.

--- a/docs/Keybinding.md
+++ b/docs/Keybinding.md
@@ -1,6 +1,7 @@
 ---
 id: Keybinding
 title: Keybinding
+author: xzntrc
 ---
 
 # Keybindings

--- a/docs/guide/getting-started/basic-programs.md
+++ b/docs/guide/getting-started/basic-programs.md
@@ -2,8 +2,11 @@
 id: basic-programs
 title: Programs
 sidebar_position: 1
+author: xzntrc
 ---
+
 # Basic Programs
 
 TempleOS is not only a full-fledged Operating System, but also comes packaged with some awesome programs and games. For obvious reasons, this page cannot contain every single program existing within TempleOS, nor are those that are detailed, done so in extreme length.
+
 ## Terminals

--- a/docs/guide/getting-started/the-basics.md
+++ b/docs/guide/getting-started/the-basics.md
@@ -2,14 +2,16 @@
 id: basics
 title: The Basics
 sidebar_position: 1
+author: xzntrc
 ---
 
 Now we can finally cover all the cool bits and pieces of TempleOS.
 
 ## Upon Booting
-Once fully inside, you'll be asked if you'd like to take the tour; thankfully, Terry was kind enough to teach people how to use his system. For the purpose of this guide, I'll be ignoring the guide and exploring things my own way - although, don't take that as an excuse to not explore the vastness of the tour, going so much as guiding you through everything. 
 
- Floating over on the right of your screen is a super helpful tool called "AutoComplete"; which - you guessed it - is a program that autocompletes what you're typing system-wide. Autocomplete can be enabled with <kbd>Alt</kbd> + <kbd>A</kbd> and disabled with <kbd>Shift</kbd>+<kbd>Alt</kbd> + <kbd>A</kbd>. From the start, we'll be greeted with two command windows or "terminals".
+Once fully inside, you'll be asked if you'd like to take the tour; thankfully, Terry was kind enough to teach people how to use his system. For the purpose of this guide, I'll be ignoring the guide and exploring things my own way - although, don't take that as an excuse to not explore the vastness of the tour, going so much as guiding you through everything.
+
+Floating over on the right of your screen is a super helpful tool called "AutoComplete"; which - you guessed it - is a program that autocompletes what you're typing system-wide. Autocomplete can be enabled with <kbd>Alt</kbd> + <kbd>A</kbd> and disabled with <kbd>Shift</kbd>+<kbd>Alt</kbd> + <kbd>A</kbd>. From the start, we'll be greeted with two command windows or "terminals".
 
 The entirety of TempleOS - disregarding a portion of assembly code - is written in a C variant created by Terry A. Davis titled **HolyC** with its own appropriately named HolyC compiler. What might be surprising about TempleOS is that the "shell" environment goes directly to the compiler, thus being completely different from something like Linux using BASH which is a standalone program used for executing programs, instead TempleOS resembles something like how the Python interpreter has its own Read-eval-print loop which feeds directly to the interpreter (although with HolyC it is way faster). Pairing one of the powerful languages with a direct user input might seem crazy, but it's ridiculously overpowered! We will be diving deeper into commands and the inner workings in the next chapter.
 
@@ -18,7 +20,9 @@ The entirety of TempleOS - disregarding a portion of assembly code - is written 
 ## The UI
 
 ### Menu
+
 From a first glimpse, TempleOS may appear very convoluted, but once you get an understanding of each component, you start to unravel its beauty. In the above image, you can see the UI for TempleOS, yours should appear the same – if not, similar – take a look at the very top, and try to make sense of it. From the left, we have our date in the format; Day MM/DD HH:MM:SS. After that, we have the current screen FPS, the maximum that this can be is 30 (without making adjustments), followed by the amount of memory in hexadecimal, then the CPU usage. In the image above, there are four 1's – or rather four slots – which represents the amount of cores allocated to the machine, the 1's themselves representing the percentage used of that core. Finally, on the very left, TempleOS displays the last key(s) pressed.
 
 ### Windows
+
 On every boot, TempleOS will open up 2 windows, both happening to be **Terminals**. In the middle of the border, surrounding the window, displays the name of the application followed by its process ID. By grabbing the top border and moving your mouse, you can reposition this window! Or, if you wish, resize them with the other borders. At the top of the window you'll find a `[X]` button, press this to close the window. What's also really cool about these windows is that they are scrollable; once enough text is filled on the screen, you will be able to scroll, of course with the mouse wheel but also by dragging that little yellow square on the border.

--- a/docs/guide/installing/methods.mdx
+++ b/docs/guide/installing/methods.mdx
@@ -2,6 +2,7 @@
 id: methods
 title: Avaliable Methods
 sidebar_position: 1
+author: xzntrc
 ---
 
 # Installation

--- a/docs/guide/installing/supplementals.md
+++ b/docs/guide/installing/supplementals.md
@@ -1,9 +1,11 @@
 ---
 id: supplementals
 title: 🧩 Supplementals
+author: xzntrc
 ---
 
 # Supplementals
+
 On some of Terry's - or other YouTubers' - videos on TempleOS, you'll notice that they have different programs than you. This is due to supplemental files; instead of packaging all of TempleOS's features into the one ISO, terry chose to split them into separate packages which can be loaded.These additions aren't necessary and are exactly that; additions. This guide will detail the installation of supplementals on most TempleOS installs. It is recommended, that if you do this, you should do it just after installing TempleOS.
 
 Regardless of your chosen method, the supplementals can be downloaded from the TempleOS Simplified Archive, you'll need to grab supplemental files one through to three, located <a href="https://archive.templeos.me/archive/TempleOS/">here</a>.
@@ -11,23 +13,31 @@ Regardless of your chosen method, the supplementals can be downloaded from the T
 ## Mounting
 
 ### QEMU
+
 Once you've installed TempleOS on a QEMU hard drive, and unmounted the CD Image, finally, make sure TempleOS is running, and you will be good to go. To start with, press the keys <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>2</kbd> to open a new QEMU console window (think of this like a TTY session on Linux), now it is time for some commands.
 
 1. Mount the first supplemental file to the CD.
+
 ```
 eject ide1-cd0
 change ide1-cd0 /home/xzntrc/VMs/TOS_Supplemental1.ISO.C
 ```
+
 If QEMU can't find `ide1-cd0` then insure it equals the correct drive visible via running `info block`.
 
 ### VMWare
+
 After directly booting into your VM, navigate to the top bar in VMWare and navigate to VM then Settings (or simply <kbd>Ctrl</kbd>+<kbd>D</kbd>). Once in the settings, press on the add button, select "CD/DVD Drive", then for the connection set it as ISO and select the first supplemental. Finish by saving.
+
 ## Back in TempleOS
+
 After mounting the first supplemental in your chosen virtual machine software, you can now move back to TempleOS and open a terminal. From here you'll need to enter the commands:
+
 ```holyc
 DskChg('T');
 CopyTree("T:/", "C:/Home/Sup1");
 ```
+
 This changes your [CWD](https://www.computerhope.com/jargon/c/currentd.htm) to drive 'T'; this is one of TempleOS's mount points, specifically this is where CDs are mounted. Upon switching directories, it copies each file in the root of 'T' to the location 'C:/Home/Sup1'. However, this is only doing this for the first supplemental, realistically though, the other two only contain Hymns and is up to you if you wish to install them.
 
 You'll now be able to run programs from the supplementals by including them.

--- a/docs/guide/installing/virtualized.mdx
+++ b/docs/guide/installing/virtualized.mdx
@@ -2,6 +2,7 @@
 id: virtualized
 title: 👾 Virtualized
 sidebar_position: 1
+author: xzntrc
 ---
 
 # Virtualized

--- a/docs/guide/intro.mdx
+++ b/docs/guide/intro.mdx
@@ -1,3 +1,7 @@
+---
+author: xzntrc
+---
+
 # Introduction
 
 [The Temple Operating System](https://www.templeos.org/) (_abbrev._ TempleOS) is a one of a kind Operating System; in fact, TempleOS has made quite a name for itself, becoming a well known legend across the interwebs; from 4Chan to [OSDev](https://wiki.osdev.org/Notable_Projects), you're bound to find some connotation to it.

--- a/docs/holyc/datastructs.mdx
+++ b/docs/holyc/datastructs.mdx
@@ -1,6 +1,7 @@
 ---
 id: datastructs
 title: Data Structures
+author: nrootconauto
 ---
 
 # Data structures

--- a/docs/holyc/doldoc_ui.mdx
+++ b/docs/holyc/doldoc_ui.mdx
@@ -1,6 +1,7 @@
 ---
 id: doldoc
 title: DolDoc
+author: nrootconauto
 ---
 
 # DolDoc

--- a/docs/holyc/getting-started.mdx
+++ b/docs/holyc/getting-started.mdx
@@ -2,6 +2,7 @@
 id: getting-started-hc
 title: Getting Started
 sidebar_position: 2
+author: xzntrc
 ---
 
 # TEST

--- a/docs/holyc/graphics.mdx
+++ b/docs/holyc/graphics.mdx
@@ -1,6 +1,7 @@
 ---
 id: graphics
 title: Graphics
+author: nrootconauto
 ---
 
 # Fun with Graphics

--- a/docs/holyc/intro.mdx
+++ b/docs/holyc/intro.mdx
@@ -2,6 +2,7 @@
 id: intro
 title: HolyC Intro
 sidebar_position: 1
+author: xzntrc
 ---
 
 _Whether you are an experienced programmer or not, this website is intended for everyone who wishes to learn the C programming language._

--- a/docs/holyc/make_a_app.mdx
+++ b/docs/holyc/make_a_app.mdx
@@ -1,6 +1,7 @@
 ---
 id: grpaint
 title: Make an Example App
+author: nrootconauto
 ---
 
 # Making an Example App

--- a/docs/holyc/print.mdx
+++ b/docs/holyc/print.mdx
@@ -1,6 +1,7 @@
 ---
 id: printing
 title: Printing
+author: nrootconauto
 ---
 
 # Printing like a pro

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useEffect, useState } from "react";
+import clsx from "clsx";
+import DocPaginator from "@theme/DocPaginator";
+import DocVersionBanner from "@theme/DocVersionBanner";
+import DocVersionBadge from "@theme/DocVersionBadge";
+import DocItemFooter from "@theme/DocItemFooter";
+import TOC from "@theme/TOC";
+import TOCCollapsible from "@theme/TOCCollapsible";
+import Heading from "@theme/Heading";
+import styles from "./styles.module.css";
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  useWindowSize,
+} from "@docusaurus/theme-common";
+import DocBreadcrumbs from "@theme/DocBreadcrumbs";
+import MDXContent from "@theme/MDXContent";
+
+function DocItemMetadata(props) {
+  const { content: DocContent } = props;
+  const { metadata, frontMatter, assets } = DocContent;
+  const { keywords } = frontMatter;
+  const { description, title } = metadata;
+  const image = assets.image ?? frontMatter.image;
+
+  return (
+    <PageMetadata
+      {...{
+        title,
+        description,
+        keywords,
+        image,
+      }}
+    />
+  );
+}
+
+function DocItemContent(props) {
+  const { content: DocContent } = props;
+  const { metadata, frontMatter } = DocContent;
+  const {
+    hide_title: hideTitle,
+    hide_table_of_contents: hideTableOfContents,
+    toc_min_heading_level: tocMinHeadingLevel,
+    toc_max_heading_level: tocMaxHeadingLevel,
+  } = frontMatter;
+  const { title } = metadata; // We only add a title if:
+  // - user asks to hide it with front matter
+  // - the markdown content does not already contain a top-level h1 heading
+
+  const shouldAddTitle =
+    !hideTitle && typeof DocContent.contentTitle === "undefined";
+  const windowSize = useWindowSize();
+  const canRenderTOC =
+    !hideTableOfContents && DocContent.toc && DocContent.toc.length > 0;
+  const renderTocDesktop =
+    canRenderTOC && (windowSize === "desktop" || windowSize === "ssr");
+
+  console.log({ DocContent });
+
+  return (
+    <div className="row">
+      <div className={clsx("col", !hideTableOfContents && styles.docItemCol)}>
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+
+            {canRenderTOC && (
+              <TOCCollapsible
+                toc={DocContent.toc}
+                minHeadingLevel={tocMinHeadingLevel}
+                maxHeadingLevel={tocMaxHeadingLevel}
+                className={clsx(
+                  ThemeClassNames.docs.docTocMobile,
+                  styles.tocMobile
+                )}
+              />
+            )}
+
+            <div className={clsx(ThemeClassNames.docs.docMarkdown, "markdown")}>
+              {/*
+               Title can be declared inside md content or declared through
+               front matter and added manually. To make both cases consistent,
+               the added title is added under the same div.markdown block
+               See https://github.com/facebook/docusaurus/pull/4882#issuecomment-853021120
+               */}
+              {shouldAddTitle && (
+                <header>
+                  <Heading as="h1">{title}</Heading>
+                </header>
+              )}
+              <MDXContent>
+                <DocContent />
+              </MDXContent>
+            </div>
+
+            {frontMatter && <AuthorDisplay author={frontMatter?.author} />}
+            <DocItemFooter {...props} />
+          </article>
+
+          <DocPaginator previous={metadata.previous} next={metadata.next} />
+        </div>
+      </div>
+      {renderTocDesktop && (
+        <div className="col col--3">
+          <TOC
+            toc={DocContent.toc}
+            minHeadingLevel={tocMinHeadingLevel}
+            maxHeadingLevel={tocMaxHeadingLevel}
+            className={ThemeClassNames.docs.docTocDesktop}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function DocItem(props) {
+  const docHtmlClassName = `docs-doc-id-${props.content.metadata.unversionedId}`;
+  return (
+    <HtmlClassNameProvider className={docHtmlClassName}>
+      <DocItemMetadata {...props} />
+      <DocItemContent {...props} />
+    </HtmlClassNameProvider>
+  );
+}
+
+function AuthorDisplay({ author }) {
+  const [data, setData] = useState(null);
+  const [isFetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    const _fetch = async () => {
+      setFetching(true);
+
+      const res = await fetch(`https://api.github.com/users/${author}`);
+
+      if (!res.ok) {
+        setFetching(false);
+        return;
+      }
+
+      const data = await res.json();
+      setData(data);
+      setFetching(false);
+    };
+
+    _fetch();
+  }, []);
+
+  if (isFetching || !data) {
+    return <></>;
+  }
+
+  const handleAuthorClick = () => {
+    window.open(`https://github.com/${author}`, "_blank");
+  };
+
+  return (
+    <div className={styles.authorWrapper}>
+      <div className={styles.authorBox} onClick={handleAuthorClick}>
+        <img src={data.avatar_url} />
+        <div>
+          <span>Written by</span>
+          <span className={styles.authorName}>{data.login}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/theme/DocItem/styles.module.css
+++ b/src/theme/DocItem/styles.module.css
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+
+  /* Prevent hydration FOUC, as the mobile TOC needs to be server-rendered */
+  .tocMobile {
+    display: none;
+  }
+}
+
+.authorWrapper {
+  padding: 1rem 2rem;
+}
+
+.authorBox {
+  padding: 1rem 2rem;
+  background: var(--prismBg);
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.authorBox > img {
+  height: 4rem; 
+  border-radius: 50%;
+}
+
+.authorBox > div {
+  display: flex;
+  flex-direction: column; 
+  margin-left: 1rem;
+}
+
+.authorName {
+  color: var(--ifm-color-primary);
+  font-weight: "bold" 
+}


### PR DESCRIPTION
This is an opt-in feature. To display the author info, the doc needs to contain an `author: github username` metadata in header. And it look like this: 

<img width="886" alt="image" src="https://user-images.githubusercontent.com/45239828/198114085-104fbff7-8254-459c-a386-89f85175c5f1.png">

I also updated current docs and added the author (found by git-blame).