### PR TITLE
Fix markdownguide.org URLs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,7 @@
 ### Contributing
 
 > **Note** <br>
-> A basic understanding of [React](https://reactjs.org/) and [Markdown](https://https://www.markdownguide.org/) may be nesseciary for editing features of TempleOS Simplified.
+> A basic understanding of [React](https://reactjs.org/) and [Markdown](https://www.markdownguide.org/) may be nesseciary for editing features of TempleOS Simplified.
 
 Upon pushing to the main branch, the site will be automatically built to the [gh-pages](https://github.com/TempleOS-Simplified/Site-Docs/tree/gh-pages) (Does not require any manual updates; all work is done on the main branch) and deployed to GitHub pages. Understanding the file structure is important to contributing to the site; it may be worth checking out the [Docsuaurs Documentation](https://docusaurus.io/docs).
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,7 @@
 # Contributing
 
 > **Note** <br>
-> A basic understanding of [React](https://reactjs.org/) and [Markdown](https://https://www.markdownguide.org/) may be nesseciary for editing _some_ features of the site.
+> A basic understanding of [React](https://reactjs.org/) and [Markdown](https://www.markdownguide.org/) may be nesseciary for editing _some_ features of the site.
 
 ## Editing
 


### PR DESCRIPTION
Typo in [`readme.md`](https://github.com/TempleOS-Simplified/Site-Docs/blob/1b4dd0249cd9e93e60ade232b68bddf7cb846bc0/README.MD?plain=1#L17) and [`contributing.md`](https://github.com/TempleOS-Simplified/Site-Docs/blob/1b4dd0249cd9e93e60ade232b68bddf7cb846bc0/contributing.md?plain=1#L4):
`https://https://www.markdownguide.org/` -> `https://www.markdownguide.org/`